### PR TITLE
Make the resultsperpage be configurable and set to 250 by default

### DIFF
--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -15,13 +15,16 @@ module SurveyGizmo
 
   class Configuration
     DEFAULT_API_VERSION = 'v4'
+    DEFAULT_RESULTS_PER_PAGE = 250
 
     attr_accessor :api_version
     attr_accessor :user
     attr_accessor :password
+    attr_accessor :results_per_page
 
     def initialize
       @api_version = DEFAULT_API_VERSION
+      @results_per_page = DEFAULT_RESULTS_PER_PAGE
     end
   end
 end

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -19,7 +19,8 @@ module SurveyGizmo
     # These are methods that every API resource can use to access resources in SurveyGizmo
     module ClassMethods
       # Get an array of resources
-      def all(conditions = {}, filters = nil)
+      def all(conditions = {}, filters = {})
+        filters[:resultsperpage] = SurveyGizmo.configuration.results_per_page unless filters[:resultsperpage]
         response = RestResponse.new(SurveyGizmo.get(handle_route(:create, conditions) + convert_filters_into_query_string(filters)))
         _collection = response.data.map { |datum| datum.is_a?(Hash) ? self.new(datum) : datum }
 
@@ -42,7 +43,7 @@ module SurveyGizmo
       end
 
       # Retrieve a single resource.
-      def first(conditions = {}, filters = nil)
+      def first(conditions = {}, filters = {})
         response = RestResponse.new(SurveyGizmo.get(handle_route(:get, conditions) + convert_filters_into_query_string(filters)))
         # Add in the properties from the conditions hash because many of the important ones (like survey_id) are
         # not often part of the SurveyGizmo's returned data
@@ -92,7 +93,7 @@ module SurveyGizmo
       # SurveyGizmo expects for its internal filtering, for example:
       #
       # filter[field][0]=istestdata&filter[operator][0]=<>&filter[value][0]=1
-      def convert_filters_into_query_string(filters = nil)
+      def convert_filters_into_query_string(filters = {})
         return '' unless filters && filters.size > 0
 
         output_filters = filters[:filters] || []

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '4.0.1'
+  VERSION = '4.0.2'
 end


### PR DESCRIPTION
@dtboctor this is a temporary hack to solve our problem with paging the surveys.  The right answer would be to embed the pagination in the `all` call for surveys, but this would cause problems with other API requests (e.g. responses, where that kind of pagination could result in a day of building the data set) so I have to sort out something better; I'll open a separate story for that.

On the plus side, using a larger pagination might help solve a longstanding issue where Surveygizmo complains about rate limit excesses (particularly when retrieving questions) despite the fact that we have to make like 10 the # of `Question` requests to get around bugs in their API.