### PR TITLE
Remove pester gem in favor of simpler Faraday based retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently supports SurveyGizmo API **v4** (default) and **v3**.
 
 ### Major Changes in 6.x
 * **BREAKING CHANGE**: SurveyGizmo changed the authentication so you need to configure `api_token` and `api_token_secret` instead of user and password.
+* **BREAKING CHANGE**: Pester has been removed as the retry source in favor of Faraday's `Request::Retry`.
 
 ### Major Changes in 5.x
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ SurveyGizmo.configure do |config|
 
   # Optional - Defaults to 300 seconds
   config.timeout_seconds = 600
+
+  # Optional - Defaults to 3 retries with a 60 second delay interval
+  config.retry_attempts = 3
+  config.retry_interval = 60
 end
 ```
 
@@ -80,31 +84,6 @@ SurveyGizmo.configure
 ````
 
 once at some point.
-
-
-### Retries
-
-The [Pester](https://github.com/lumoslabs/pester) gem is used to manage retry strategies.  By default it will be configured to handle 1 retry with a 60 second timeout upon encountering basic net timeouts and rate limit errors, which is enough for most people's needs.
-
-If, however, you want to specify more retries, a longer backoff, new classes to retry on, or otherwise get fancy with the retry strategy, you can configured Pester directly.  SurveyGizmo API calls are executed in Pester's `survey_gizmo_ruby` environment, so anything you configure there will apply to all your requests.
-
-```ruby
-# For example, to change the retry interval, max attempts, or exception classes to be retried:
-Pester.configure do |config|
-  # Retry 10 times
-  config.environments[:survey_gizmo_ruby][:max_attempts] = 10
-  # Backoff for 2 minutes
-  config.environments[:survey_gizmo_ruby][:delay_interval] = 120
-  # Retry different exception classes
-  config.environments[:survey_gizmo_ruby][:retry_error_classes] = [MyExceptionClass, MyOtherExceptionClass]
-end
-
-# To set Pester to retry on ALL exception classes, do this:
-# (use with caution! Can include exceptions Rails likes to throw on SIGHUP)
-Pester.configure do |config|
-  config.environments[:survey_gizmo_ruby][:retry_error_classes] = nil
-end
-```
 
 ## Usage
 

--- a/lib/survey-gizmo-ruby.rb
+++ b/lib/survey-gizmo-ruby.rb
@@ -11,7 +11,6 @@ require 'digest/md5'
 require 'faraday'
 require 'faraday_middleware'
 require 'logger'
-require 'pester'
 require 'virtus'
 
 path = File.join(File.expand_path(File.dirname(__FILE__)), 'survey_gizmo')

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -10,40 +10,14 @@ module SurveyGizmo
     def configure
       @configuration ||= Configuration.new
       yield(configuration) if block_given?
-      configure_pester
     end
 
     def reset!
       self.configuration = Configuration.new
-      Pester.configure { |c| c.environments[:survey_gizmo_ruby] = nil }
-      configure_pester
       Connection.reset!
     end
 
     private
-
-    def configure_pester
-      default_config = {
-        on_retry: Pester::Behaviors::Sleep::Constant,
-        logger: configuration.logger,
-        max_attempts: 2,
-        delay_interval: 60,
-        retry_error_classes: retryables
-      }
-
-      Pester.configure do |c|
-        if c.environments[:survey_gizmo_ruby].nil?
-          c.environments[:survey_gizmo_ruby] = default_config
-        else
-          default_config.each { |k,v| c.environments[:survey_gizmo_ruby][k] ||= v unless k == :retry_error_classes }
-
-          # Don't set :retry_error_classes to something when user has configured nothing
-          if c.environments[:survey_gizmo_ruby][:retry_error_classes].nil? && !c.environments[:survey_gizmo_ruby].has_key?(:retry_error_classes)
-            c.environments[:survey_gizmo_ruby][:retry_error_classes] = retryables
-          end
-        end
-      end
-    end
 
     def retryables
       [
@@ -59,6 +33,8 @@ module SurveyGizmo
     DEFAULT_API_VERSION = 'v4'
     DEFAULT_RESULTS_PER_PAGE = 50
     DEFAULT_TIMEOUT_SECONDS = 300
+    DEFAULT_RETRIES = 3
+    DEFAULT_RETRY_INTERVAL = 60
 
     attr_accessor :api_token
     attr_accessor :api_token_secret
@@ -68,7 +44,11 @@ module SurveyGizmo
     attr_accessor :api_version
     attr_accessor :logger
     attr_accessor :results_per_page
+
     attr_accessor :timeout_seconds
+    attr_accessor :retry_attempts
+    attr_accessor :retry_interval
+
 
     def initialize
       @api_token = ENV['SURVEYGIZMO_API_TOKEN'] || nil
@@ -77,7 +57,11 @@ module SurveyGizmo
       @api_url = DEFAULT_REST_API_URL
       @api_version = DEFAULT_API_VERSION
       @results_per_page = DEFAULT_RESULTS_PER_PAGE
+
       @timeout_seconds = DEFAULT_TIMEOUT_SECONDS
+      @retry_attempts = DEFAULT_RETRIES
+      @retry_interval = DEFAULT_RETRY_INTERVAL
+
       @logger = SurveyGizmo::Logger.new(STDOUT)
       @api_debug = ENV['GIZMO_DEBUG'].to_s =~ /^(true|t|yes|y|1)$/i
     end

--- a/lib/survey_gizmo/connection.rb
+++ b/lib/survey_gizmo/connection.rb
@@ -24,7 +24,20 @@ module SurveyGizmo
           }
         }
 
+        retry_options = {
+          max: SurveyGizmo.configuration.retry_attempts,
+          interval: SurveyGizmo.configuration.retry_interval,
+          exceptions: [
+            BadResponseError,
+            RateLimitExceededError,
+            Errno::ETIMEDOUT,
+            'Timeout::Error',
+            'Error::TimeoutError'
+          ]
+        }
+
         @connection ||= Faraday.new(options) do |connection|
+          connection.request :retry, retry_options
           connection.request :url_encoded
 
           connection.response :parse_survey_gizmo_data

--- a/lib/survey_gizmo/faraday_middleware/pester_survey_gizmo.rb
+++ b/lib/survey_gizmo/faraday_middleware/pester_survey_gizmo.rb
@@ -6,12 +6,10 @@ module SurveyGizmo
     Faraday::Response.register_middleware(pester_survey_gizmo: self)
 
     def call(environment)
-      Pester.survey_gizmo_ruby.retry do
-        @app.call(environment).on_complete do |response|
-          fail RateLimitExceededError if response.status == 429
-          fail BadResponseError, "Bad response code #{response.status} in #{response.inspect}" unless response.status == 200
-          fail BadResponseError, response.body['message'] unless response.body['result_ok'] && response.body['result_ok'].to_s =~ /^true$/i
-        end
+      @app.call(environment).on_complete do |response|
+        fail RateLimitExceededError if response.status == 429
+        fail BadResponseError, "Bad response code #{response.status} in #{response.inspect}" unless response.status == 200
+        fail BadResponseError, response.body['message'] unless response.body['result_ok'] && response.body['result_ok'].to_s =~ /^true$/i
       end
     end
   end

--- a/lib/survey_gizmo/logger.rb
+++ b/lib/survey_gizmo/logger.rb
@@ -3,7 +3,7 @@ require 'logger'
 module SurveyGizmo
   class Logger < ::Logger
     def format_message(severity, timestamp, progname, msg)
-      msg.gsub!(/#{Regexp.quote(SurveyGizmo.configuration.api_token_secret)}/, '<SG_API_KEY>') if SurveyGizmo.configuration.api_token
+      msg.gsub!(/#{Regexp.quote(SurveyGizmo.configuration.api_token)}/, '<SG_API_KEY>') if SurveyGizmo.configuration.api_token
       msg.gsub!(/#{Regexp.quote(SurveyGizmo.configuration.api_token_secret)}/, '<SG_API_SECRET>') if SurveyGizmo.configuration.api_token_secret
 
       "#{timestamp.strftime('%Y-%m-%d %H:%M:%S')} #{severity} #{msg}\n"

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '6.0.0'
+  VERSION = '6.0.1'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,12 +14,11 @@ RSpec.configure do |config|
     SurveyGizmo.configure do |config|
       config.api_token = 'king_of_the_whirled'
       config.api_token_secret = 'dreamword'
-      config.logger.level = Logger::FATAL
-    end
 
-    Pester.configure do |config|
-      config.environments[:survey_gizmo_ruby][:logger] = ::Logger.new(nil)
-      config.environments[:survey_gizmo_ruby][:max_attempts] = 1
+      config.retry_attempts = 0
+      config.retry_interval = 0
+
+      config.logger.level = Logger::FATAL
     end
 
     @base = "#{SurveyGizmo.configuration.api_url}/#{SurveyGizmo.configuration.api_version}"

--- a/survey-gizmo-ruby.gemspec
+++ b/survey-gizmo-ruby.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '>= 0.9.1', '~> 0.9'
   gem.add_dependency 'faraday_middleware', '~> 0.10'
   gem.add_dependency 'i18n'
-  gem.add_dependency 'pester', '>= 1.0.0'
   gem.add_dependency 'virtus', '>= 1.0.0'
 
   gem.add_development_dependency 'rspec', '~> 2.11.0'


### PR DESCRIPTION
@rfroetscher we noticed [an issue](https://github.com/jarthod/survey-gizmo-ruby/issues/60) with PUT, DELETE, etc, where we weren't reencoding the request correctly.  Somehow this suddenly started affecting even basic GET retries, which had been working - maybe because of AWS-SDK patches to Net::HTTP.

Either way, it seems Faraday has a reasonable `retry` middleware already, so I just switched over to that.

