### PR TITLE
Bugfix mask cgi escaped tokens (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Versions
 
+## 6.2.11
+* Bugfix: Mask CGI escaped (percent encoded) api tokens in logs
+
 ## 6.2.10
 * Fix question pipe parsing when there's an integer without quotes instead of a quoted string (#87)
 

--- a/lib/survey_gizmo/logger.rb
+++ b/lib/survey_gizmo/logger.rb
@@ -2,11 +2,22 @@ require 'logger'
 
 module SurveyGizmo
   class Logger < ::Logger
-    def format_message(severity, timestamp, progname, msg)
-      msg.gsub!(/#{Regexp.quote(SurveyGizmo.configuration.api_token)}/, '<SG_API_KEY>') if SurveyGizmo.configuration.api_token
-      msg.gsub!(/#{Regexp.quote(SurveyGizmo.configuration.api_token_secret)}/, '<SG_API_SECRET>') if SurveyGizmo.configuration.api_token_secret
+    def format_message(severity, timestamp, progname, message)
+      if (api_token = SurveyGizmo.configuration.api_token)
+        message.gsub!(
+          /#{Regexp.quote(api_token)}|#{Regexp.quote(CGI.escape(api_token))}/,
+          '<SG_API_KEY>'
+        )
+      end
 
-      "#{timestamp.strftime('%Y-%m-%d %H:%M:%S')} #{severity} #{msg}\n"
+      if (api_token_secret = SurveyGizmo.configuration.api_token_secret)
+        message.gsub!(
+          /#{Regexp.quote(api_token_secret)}|#{Regexp.quote(CGI.escape(api_token_secret))}/,
+          '<SG_API_SECRET>'
+        )
+      end
+
+      "#{timestamp.strftime('%Y-%m-%d %H:%M:%S')} #{severity} #{message}\n"
     end
   end
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '6.2.10'
+  VERSION = '6.2.11'
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe SurveyGizmo::Configuration do
+  before(:each) do
+    SurveyGizmo.configure do |config|
+      config.api_token = 'king_of_the&whirled$'
+      config.api_token_secret = 'dream/word'
+    end
+    @severity = 'INFO'
+    @time_string = '2015-04-15 05:46:30'
+    @progname = 'TEST'
+  end
+
+  after(:each) do
+    SurveyGizmo.reset!
+  end
+
+  it 'should mask unencoded api token' do
+    config = SurveyGizmo.configuration
+    formatted_message = config.logger.format_message(
+      @severity,
+      @time_string.to_time,
+      @progname,
+      config.api_token
+    )
+    expect(
+      formatted_message
+    ).to eq(
+      "#{@time_string} #{@severity} <SG_API_KEY>\n"
+    )
+  end
+
+  it 'should mask percent encoded api token' do
+    config = SurveyGizmo.configuration
+    formatted_message = config.logger.format_message(
+      @severity,
+      @time_string.to_time,
+      @progname,
+      CGI.escape(config.api_token)
+    )
+    expect(
+      formatted_message
+    ).to eq(
+      "#{@time_string} #{@severity} <SG_API_KEY>\n"
+    )
+  end
+
+  it 'should mask unencoded api token secret' do
+    config = SurveyGizmo.configuration
+    formatted_message = config.logger.format_message(
+      @severity,
+      @time_string.to_time,
+      @progname,
+      config.api_token_secret
+    )
+    expect(
+      formatted_message
+    ).to eq(
+      "#{@time_string} #{@severity} <SG_API_SECRET>\n"
+    )
+  end
+
+  it 'should mask percent encoded api token secret' do
+    config = SurveyGizmo.configuration
+    formatted_message = config.logger.format_message(
+      @severity,
+      @time_string.to_time,
+      @progname,
+      CGI.escape(config.api_token_secret)
+    )
+    expect(
+      formatted_message
+    ).to eq(
+      "#{@time_string} #{@severity} <SG_API_SECRET>\n"
+    )
+  end
+end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -22,15 +22,15 @@ describe 'Survey Gizmo Resource' do
     it '#reload' do
       stub_request(:get, /#{@base}/).to_return(json_response(true, get_attributes))
       obj = described_class.new(get_attributes.merge(update_attributes))
-      obj.attributes.reject { |k, v| v.blank? }.should == get_attributes.merge(update_attributes)
+      expect(obj.attributes.reject { |k, v| v.blank? }).to eq(get_attributes.merge(update_attributes))
       obj.reload
-      obj.attributes.reject { |k, v| v.blank? }.should == get_attributes
+      expect(obj.attributes.reject { |k, v| v.blank? }).to eq(get_attributes)
     end
 
     it 'should raise an error if params are missing' do
-      lambda {
+      expect(lambda {
         SurveyGizmoSpec::ResourceTest.destroy(test_id: 5)
-      }.should raise_error(SurveyGizmo::URLError, 'Missing RESTful parameters in request: `:id`')
+      }).to raise_error(SurveyGizmo::URLError, 'Missing RESTful parameters in request: `:id`')
     end
 
     it_should_behave_like 'an API object'
@@ -73,8 +73,8 @@ describe 'Survey Gizmo Resource' do
       stub_request(:get, /#{@base}\/survey\/1\/surveyresponse/).to_return(json_response(true, []))
 
       survey = described_class.new(id: 1)
-      expect(survey.server_has_new_results_since?(Time.now)).to be_false
-      a_request(:get, /#{@base}\/survey\/1\/surveyresponse/).should have_been_made
+      expect(survey.server_has_new_results_since?(Time.now)).to be_falsey
+      expect(a_request(:get, /#{@base}\/survey\/1\/surveyresponse/)).to have_been_made
     end
   end
 
@@ -100,13 +100,13 @@ describe 'Survey Gizmo Resource' do
     end
 
     it 'should handle the _subtype key' do
-      described_class.new(:_subtype => 'radio').type.should == 'radio'
+      expect(described_class.new(:_subtype => 'radio').type).to eq('radio')
     end
 
     it 'should find the survey' do
       stub_request(:get, /#{@base}\/survey\/1234/).to_return(json_response(true, get_attributes))
       described_class.new(base_params).survey
-      a_request(:get, /#{@base}\/survey\/1234/).should have_been_made
+      expect(a_request(:get, /#{@base}\/survey\/1234/)).to have_been_made
     end
 
     context 'options' do
@@ -139,17 +139,17 @@ describe 'Survey Gizmo Resource' do
 
         it 'correctly parses options out of question data' do
           question = described_class.first(survey_id: survey_id, id: question_id)
-          expect(question.options.all? { |o| o.question_id == question_id && o.survey_id == survey_id }).to be_true
+          expect(question.options.all? { |o| o.question_id == question_id && o.survey_id == survey_id }).to be_truthy
           expect(question.options.map { |o| o.id }).to eq([10014, 10015])
-          a_request(:get, /#{@base}\/.*surveyoption/).should_not have_been_made
+          expect(a_request(:get, /#{@base}\/.*surveyoption/)).to_not have_been_made
         end
 
         it 'correctly parses sub question options' do
           question = described_class.new(survey_id: survey_id, id: question_id + 1, parent_question_id: question_id)
           expect(question.parent_question.id).to eq(described_class.new(body_data).id)
-          expect(question.options.all? { |o| o.question_id == question.id && o.survey_id == survey_id }).to be_true
+          expect(question.options.all? { |o| o.question_id == question.id && o.survey_id == survey_id }).to be_truthy
           expect(question.options.map { |o| o.id }).to eq([10014, 10015])
-          a_request(:get, /#{@base}\/survey\/#{survey_id}\/surveyquestion\/#{question_id}/).should have_been_made
+          expect(a_request(:get, /#{@base}\/survey\/#{survey_id}\/surveyquestion\/#{question_id}/)).to have_been_made
         end
       end
     end
@@ -168,8 +168,10 @@ describe 'Survey Gizmo Resource' do
         expect(question_with_subquestions.sub_questions.size).to eq(2)
 
         question_with_subquestions.sub_questions.first.parent_question
-        a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{parent_id}/).should have_been_made
-        skus.each { |sku| a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{sku}/).should have_been_made }
+        expect(a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{parent_id}/)).to have_been_made
+        skus.each do |sku|
+          expect(a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{sku}/)).to have_been_made
+        end
       end
 
       context 'and shortname' do
@@ -181,8 +183,8 @@ describe 'Survey Gizmo Resource' do
           expect(question_with_subquestions.sub_questions.size).to eq(2)
 
           question_with_subquestions.sub_questions.first.parent_question
-          a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{parent_id}/).should have_been_made
-          a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{sku}/).should have_been_made
+          expect(a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{parent_id}/)).to have_been_made
+          expect(a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{sku}/)).to have_been_made
         end
       end
     end

--- a/spec/support/spec_shared_api_object.rb
+++ b/spec/support/spec_shared_api_object.rb
@@ -8,7 +8,7 @@ shared_examples_for 'an API object' do
       stub_api_call(:put)
       obj = described_class.create(create_attributes)
 
-      obj.should be_instance_of(described_class)
+      expect(obj).to be_instance_of(described_class)
       a_request(:put, /#{@base}#{uri_paths[:create]}/).should have_been_made
     end
 
@@ -16,7 +16,7 @@ shared_examples_for 'an API object' do
       stub_request(:put, /#{@base}/).to_return(json_response(true, create_attributes))
       obj = described_class.create(create_attributes)
 
-      obj.attributes.reject { |k, v| v.blank? }.should == (create_attributes_to_compare || create_attributes)
+      expect(obj.attributes.reject { |k, v| v.blank? }).to eq(create_attributes_to_compare || create_attributes)
     end
   end
 
@@ -24,8 +24,8 @@ shared_examples_for 'an API object' do
     it "should make a request and set the attributes" do
       stub_request(:get, /#{@base}/).to_return(json_response(true, get_attributes))
       obj = described_class.first(first_params)
-      a_request(:get, /#{@base}#{uri_paths[:get]}/).should have_been_made
-      obj.attributes.reject { |k, v| v.blank? }.should == (get_attributes_to_compare || get_attributes)
+      expect(a_request(:get, /#{@base}#{uri_paths[:get]}/)).to have_been_made
+      expect(obj.attributes.reject { |k, v| v.blank? }).to eq(get_attributes_to_compare || get_attributes)
     end
 
     it "should return false if the request fails" do
@@ -42,7 +42,7 @@ shared_examples_for 'an API object' do
     it "should make a request" do
       stub_api_call(:delete)
       @obj.destroy
-      a_request(:delete, /#{@base}#{uri_paths[:delete]}/).should have_been_made
+      expect(a_request(:delete, /#{@base}#{uri_paths[:delete]}/)).to have_been_made
     end
 
     it "cannot be destroyed if new" do
@@ -55,12 +55,12 @@ shared_examples_for 'an API object' do
     it "should make a request" do
       stub_api_call(:delete)
       described_class.destroy(first_params)
-      a_request(:delete, /#{@base}#{uri_paths[:delete]}/).should have_been_made
+      expect(a_request(:delete, /#{@base}#{uri_paths[:delete]}/)).to have_been_made
     end
 
     it "should return result" do
       stub_api_call(:delete)
-      described_class.destroy(first_params).should be_true
+      expect(described_class.destroy(first_params)).to be_truthy
     end
   end
 
@@ -69,14 +69,14 @@ shared_examples_for 'an API object' do
       stub_api_call(:put)
       obj = described_class.new(create_attributes)
       obj.save
-      a_request(:put, /#{@base}#{uri_paths[:create]}/).should have_been_made
+      expect(a_request(:put, /#{@base}#{uri_paths[:create]}/)).to have_been_made
     end
 
     it "should call update on a created resource" do
       obj = described_class.new(get_attributes)
       stub_api_call(:post)
       obj.save
-      a_request(:post, /#{@base}#{uri_paths[:update]}/).should have_been_made
+      expect(a_request(:post, /#{@base}#{uri_paths[:update]}/)).to have_been_made
     end
   end
 
@@ -92,11 +92,11 @@ shared_examples_for 'an API object' do
     it "should make a get request" do
       stub_request(:get, /#{@base}/).to_return(json_response(true, data))
       iterator = described_class.all(get_attributes.merge(page: 1))
-      iterator.should be_instance_of(Enumerator)
+      expect(iterator).to be_instance_of(Enumerator)
       collection = iterator.to_a
-      a_request(:get, /#{@base}#{uri_paths[:create]}/).should have_been_made
-      collection.first.should be_instance_of(described_class)
-      collection.length.should == 3
+      expect(a_request(:get, /#{@base}#{uri_paths[:create]}/)).to have_been_made
+      expect(collection.first).to be_instance_of(described_class)
+      expect(collection.length).to eq(3)
     end
   end
 end

--- a/survey-gizmo-ruby.gemspec
+++ b/survey-gizmo-ruby.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'i18n'
   gem.add_dependency 'virtus', '>= 1.0.0'
 
-  gem.add_development_dependency 'rspec', '~> 2.11.0'
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rspec', '~> 3.4.0'
+  gem.add_development_dependency 'rake', '~> 12.0.0'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'yard'
 


### PR DESCRIPTION
* Bugfix: mask cgi escaped (percent encoded) api tokens in logs

* Refactor: Re-adding guard clauses that check for presence of api_token and api_token_secret

* Refactor[PR-#91]: adding OR to regex instead of repeating gsub statements

* Feature[PR-#91]: added spec for masking of api tokens

* Other: correct name for percent encoded api secret spec

* Refactor[PR-#91]: use safe assignment idiom

* Feature[PR-#91]: version bump to 6.2.11 with changelog entry

* Feature[PR-#91]: updating rake and rspec, replacing deprecated should syntax with expect syntax in specs